### PR TITLE
Use AWS Lambda Environment Variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,25 +37,27 @@ npm install
 
 This is a prerequisite for deployment as AWS Lambda requires these files to be included in a bundle (a special ZIP file).
 
-Create a `.env` file by copying the sample:
+## Local testing
+
+Configure the local environment with a `.env` file by copying the sample:
 
 ```bash
-cp ./.env.sample ./.env
+cp .env.sample .env
 ```
+
+### Environment Variables
 
 Modify the `.env`:
 * `TOKEN_ISSUER`: The issuer of the token. If you're using Auth0 as the token issuer, this would be: `https://your-tenant.auth0.com/`
 * `JWKS_URI`: This is the URL of the associated JWKS endpoint. If you are using Auth0 as the token issuer, this would be: `https://your-tenant.auth0.com/.well-known/jwks.json`
 * `AUDIENCE`: This is the required audience of the token. If you are using Auth0 as the Authorization Server, the audience value is the same thing as your API **Identifier** for the specific API in your [APIs section]((https://manage.auth0.com/#/apis)).
 
-## Local testing
-
 You can test the custom authorizer locally. You just need to obtain a valid JWT access token to perform the test. If you're using Auth0, see [these instructions](https://auth0.com/docs/tokens/access-token#how-to-get-an-access-token) on how to obtain one.
 
 With a valid token, now you just need to create a local `event.json` file that contains it. Start by copying the sample file:
 
 ```bash
-cp ./event.json.sample ./event.json
+cp event.json.sample event.json
 ```
 
 Then replace the `ACCESS_TOKEN` text in that file with the JWT you obtained in the previous step.
@@ -183,6 +185,7 @@ Now we can finally create the lamda function itself in AWS. Start by going to [c
 * _Lambda function code_
     * Code entry type: `Update a .ZIP file`
     * Function package: (upload the `custom-authorizer.zip` file created earlier)
+    * Environment variables: (create variables with the same _Key_ and _Value_ as the list in the [Environment Variables](#environment-variables) section above)
 * _Lambda function handler and role_
     * Handler: `index.handler` (default)
     * Role: `Choose an existing role`

--- a/lib.js
+++ b/lib.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('dotenv').config();
+require('dotenv').config({ silent: true });
 var jwksClient = require('jwks-rsa');
 var jwt = require('jsonwebtoken');
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "./node_modules/.bin/lambda-local --timeout 300 --lambdapath index.js --eventpath event.json",
-    "bundle": "rm -f custom-authorizer.zip ; zip custom-authorizer.zip -r *.js *.json .env node_modules/"
+    "bundle": "rm -f custom-authorizer.zip ; zip custom-authorizer.zip -r *.js *.json node_modules/"
   },
   "author": "Jason Haines",
   "license": "Apache-2.0",


### PR DESCRIPTION
Instead of bundling the `.env` file into the ZIP file, require environment variables to be set in the AWS Lambda itself. This makes it easy to swap out settings without having to redeploy.