### PR TITLE
Missing error handling

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -50,13 +50,18 @@ module.exports.authenticate = function (params, cb) {
     });
 
     var decoded = jwt.decode(token, { complete: true });
-    var kid = decoded.header.kid;
+    try {
+        var kid = decoded.header.kid;
+    }
+    catch (err) {
+        cb(err);
+    }
     client.getSigningKey(kid, function (err, key) {
         if(err)
         {
              cb(err);
         }
-        else 
+        else
         {
         var signingKey = key.publicKey || key.rsaPublicKey;
         jwt.verify(token, signingKey, { audience: process.env.AUDIENCE, issuer: process.env.TOKEN_ISSUER },


### PR DESCRIPTION
Missing error handling for when authorisation token isn't a valid jwt
token.

Couldn't find how to open an issue, didn't know how to contact maintainers otherwise

Kind regards, Pudi