### PR TITLE
Remove ./node_modules/.bin/ reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "An AWS Lambda function to provide a Custom Authenticator for AWS API Gateway that verifies RS* signed tokens",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/.bin/lambda-local --timeout 300 --lambdapath index.js --eventpath event.json",
+    "test": "lambda-local --timeout 300 --lambdapath index.js --eventpath event.json",
     "bundle": "rm -f custom-authorizer.zip ; zip custom-authorizer.zip -r *.js *.json node_modules/"
   },
   "author": "Jason Haines",


### PR DESCRIPTION
Removed the reference to ./node_modules/.bin/ from test script. References to node_modules bin scrips are not needed.